### PR TITLE
Removing underscore dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "grunt-contrib-watch": "^1.0.0"
   },
   "dependencies": {
-    "base-64": "~0.1.0",
-    "fs-extra": "~2.1.2"
+    "base-64": "~0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "base-64": "~0.1.0",
-    "fs-extra": "~2.1.2",
-    "underscore": "~1.8.3"
+    "fs-extra": "~2.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xendit-js-node",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "JS client library for tokenizing credit cards as node modules",
   "main": "./src/xendit.js",
   "repository": {


### PR DESCRIPTION
Changes:
- [x] remove underscore in package dependency (not being used in the package). Based on security issue https://github.com/xendit/xendit-js-node/security/dependabot