### PR TITLE
Add currency to body of _createCreditCardToken

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -221,6 +221,7 @@ Card.prototype._createCreditCardToken = function (tokenData, callback) {
             cvn: tokenData.card_cvn
         },
         should_authenticate: tokenData.should_authenticate,
+        currency: tokenData.currency && tokenData.currency
     };
     
     if(!body.is_single_use && body.card_data.cvn === '' || body.card_data.cvn === null) {


### PR DESCRIPTION
In `_createCreditCardToken` I added the `curency` property as it was missing. Without it the tokenization process does not know which currency you are using.

I need to specify currency as 'PHP' as if it is 'IDR' which is the default, amount needs to be an integer instead of possibly a decimal for Philippine currency.

Thanks and feel free to ask me any questions or concerns you may have.

